### PR TITLE
Fix clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -104,7 +104,7 @@ SortIncludes: true
 ### Namespaces
 NamespaceIndentation: All
 CompactNamespaces: false
-FixNamespaceComments: true
+FixNamespaceComments: false
 
 ### Penalties
 # PenaltyBreakAssignment: (unsigned) The penalty for breaking around an assignment operator.

--- a/source/fl/game.cpp
+++ b/source/fl/game.cpp
@@ -1,10 +1,9 @@
 #include "fl/game.h"
 
+#include "game/GameData/GameDataFunction.h"
+#include "game/Player/PlayerActorHakoniwa.h"
+#include "game/StageScene/StageScene.h"
 #include "rs/util.hpp"
-
-#include <game/GameData/GameDataFunction.h>
-#include <game/Player/PlayerActorHakoniwa.h>
-#include <game/StageScene/StageScene.h>
 
 namespace fl {
 	void Game::setStageScene(StageScene *stage_scene) {


### PR DESCRIPTION
After initially applying the clang-format, some of the includes were reordered and the build failed. This update re-reorders the includes so that build completes and the clang-format is adhered to.

The clang-format was also updated to no longer add ``// namespace ...`` comments at the end of namespaces.