### PR TITLE
Block gravity change during capture

### DIFF
--- a/source/fl/ui/p_misc.cpp
+++ b/source/fl/ui/p_misc.cpp
@@ -57,21 +57,24 @@ void fl::ui::misc::update(PracticeUI &ui) {
 	else if (gravity > 5)
 		gravity = 0;
 	PlayerActorHakoniwa *player = rs::getPlayerActor(stageScene);
+
+	// After a capture, don't change gravity. Passing currentHackActor to setGravity currently crashes the game.
 	al::LiveActor *o = player;
-	if (player->mHackKeeper->currentHackActor)
-		o = player->mHackKeeper->currentHackActor;
-	if (gravity == 0)
-		al::setGravity(o, {0, -1, 0});
-	else if (gravity == 1)
-		al::setGravity(o, {0, 1, 0});
-	else if (gravity == 2)
-		al::setGravity(o, {1, 0, 0});
-	else if (gravity == 3)
-		al::setGravity(o, {-1, 0, 0});
-	else if (gravity == 4)
-		al::setGravity(o, {0, 0, 1});
-	else if (gravity == 5)
-		al::setGravity(o, {0, 0, -1});
+	if (!player->mHackKeeper->currentHackActor) {
+		if (gravity == 0)
+			al::setGravity(o, {0, -1, 0});
+		else if (gravity == 1)
+			al::setGravity(o, {0, 1, 0});
+		else if (gravity == 2)
+			al::setGravity(o, {1, 0, 0});
+		else if (gravity == 3)
+			al::setGravity(o, {-1, 0, 0});
+		else if (gravity == 4)
+			al::setGravity(o, {0, 0, 1});
+		else if (gravity == 5)
+			al::setGravity(o, {0, 0, -1});
+	}
+
 	ui.addLine();
 	ui.printf("%sWiggler Pattern: %s\n", ui.curLine == 8 ? ">" : "", ui.curPattern == PracticeUI::MofumofuPattern::Random ? "Random" : ui.mPatternEntries[ui.curPattern].typeStr);
 	if (al::isPadTriggerRight(CONTROLLER_AUTO) && ui.curLine == 8)

--- a/source/fl/ui/p_misc.cpp
+++ b/source/fl/ui/p_misc.cpp
@@ -30,6 +30,8 @@ void fl::ui::misc::update(PracticeUI &ui) {
 	static u8 gravity = 0;
 	ui.cursor(7);
 	const char *gravityString = nullptr;
+	const char *gravityBlocked = nullptr;
+
 	if (gravity == 0)
 		gravityString = "Down";
 	else if (gravity == 1)
@@ -43,8 +45,15 @@ void fl::ui::misc::update(PracticeUI &ui) {
 	else if (gravity == 5)
 		gravityString = "West";
 
+	// After a capture, don't change gravity. Passing currentHackActor to setGravity currently crashes the game.
+	PlayerActorHakoniwa *player = rs::getPlayerActor(stageScene);
+	if (player->mHackKeeper->currentHackActor)
+		gravityBlocked = " (blocked: capture active)";
+	else
+		gravityBlocked = "";
+
 	bool gravityChanged = false;
-	ui.printf("Gravity: %s\n", gravityString);
+	ui.printf("Gravity: %s%s\n", gravityString, gravityBlocked);
 	if (ui.curLine == 7 && ui.inputEnabled && !ui.nextFrameNoLeftInput && al::isPadTriggerLeft(CONTROLLER_AUTO)) {
 		gravity--;
 		gravityChanged = true;
@@ -56,7 +65,6 @@ void fl::ui::misc::update(PracticeUI &ui) {
 		gravity = 5;
 	else if (gravity > 5)
 		gravity = 0;
-	PlayerActorHakoniwa *player = rs::getPlayerActor(stageScene);
 
 	// After a capture, don't change gravity. Passing currentHackActor to setGravity currently crashes the game.
 	al::LiveActor *o = player;


### PR DESCRIPTION
Since the game crashes when setting the gravity during a capture, this prevents the mod from setting the gravity when a capture is active.

I have not currently found a way to set the gravity for captures.

Fixes #8.