### PR TITLE
Fix accidental save position

### DIFF
--- a/source/fl/ui/p_stages.cpp
+++ b/source/fl/ui/p_stages.cpp
@@ -57,7 +57,7 @@ void fl::ui::stages::update(PracticeUI &ui) {
 	ui.addLine();
 	ui.cursor(2);
 	if (currentScenario != -1) {
-		if (currentStage < 15) {
+		if (currentStage < 17) {
 			const char *description = stageNameDescriptions[currentStage][currentScenario - 1];
 			ui.printf("Scenario: %d (%s)\n", currentScenario, description);
 		} else

--- a/source/fl/ui/ui.cpp
+++ b/source/fl/ui/ui.cpp
@@ -75,8 +75,16 @@ void fl::ui::PracticeUI::update(StageScene *stageScene) {
 
 	if (!showMenu || (!inputEnabled && !holdL)) {
 		if (teleportEnabled) {
+			// If holdL is true and the left D-pad is pressed, that means showMenu is only false
+			// because we just hid the menu. And hiding the menu shouldn't save Mario's position.
+#if SMOVER == 100
 			if (al::isPadTriggerLeft(CONTROLLER_AUTO))
 				savePosition(*player);
+#endif
+#if SMOVER == 130
+			if (al::isPadTriggerLeft(CONTROLLER_AUTO) && !holdL)
+				savePosition(*player);
+#endif
 
 			if (al::isPadTriggerRight(CONTROLLER_AUTO) && saved)
 				loadPosition(*player);


### PR DESCRIPTION
When hiding the mod menu with teleportation enabled in SMO v1.3.0, this would also save Mario's position. This change would prevent that from happening.